### PR TITLE
Allow wildcard close tag for block elements

### DIFF
--- a/src/parser/recoverable.rs
+++ b/src/parser/recoverable.rs
@@ -61,6 +61,8 @@ pub struct RecoveryConfig {
     /// html, and should be provided as is.
     pub(crate) raw_text_elements: HashSet<&'static str>,
     pub(crate) transform_block: Option<Rc<TransformBlockFn>>,
+    /// Allows wildcard closing tag matching for blocks
+    pub(crate) block_element_close_wildcard: Option<Rc<dyn Fn(&syn::Block) -> bool>>,
 }
 
 impl Debug for RecoveryConfig {
@@ -217,6 +219,7 @@ impl From<crate::ParserConfig> for RecoveryConfig {
             raw_text_elements: config.raw_text_elements.clone(),
             always_self_closed_elements: config.always_self_closed_elements.clone(),
             transform_block: config.transform_block.clone(),
+            block_element_close_wildcard: config.block_element_close_wildcard.clone(),
         }
     }
 }


### PR DESCRIPTION
As noted in https://github.com/rs-tml/rstml/issues/11 (does not close, but adds functionality discussed)

Currently, while permitted, it is inconvenient to use blocks as element open tag names. You must make sure the close block matches exactly.

```rust
example! {
    <{"FooBar"}>{"My content"}</{"FooBar"}>
}
```

This is inconvenient if you want to do anything non trivial in one of these blocks.

The changes in this pull request allow you to do the following instead.

```rust
example! {
    <{ does_something_non_trivial() }>{"My content"}</{..}>
}
```

The enabling, and exact syntax of the wildcard, is configurable via a config option:

```rust
let config = ParserConfig::new().block_element_close_wildcard(|block| {
    // Allow </{..}> as wildcard closing tag
    matches!(
        &block.stmts[..],
        &[Stmt::Expr(
            Expr::Range(ExprRange {
                start: None,
                limits: RangeLimits::HalfOpen(_),
                end: None,
                ..
            }),
            None
        )]
    )
});
```

The above is included as an example in the documentation for enabling `</{..}>` wildcards, though I am certain others may be desirable.

When enabled, wildcards can only be used to close block element open tags. When disabled, behaviour is as currently implemented.