### PR TITLE
feat: allow disabling color diagnostics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ quote = "1.0.21"
 syn = { version = "2.0.15", features = ["full", "parsing", "extra-traits"] }
 thiserror = "1.0.37"
 syn_derive = "0.1.6"
-proc-macro2-diagnostics = "0.10"
+proc-macro2-diagnostics = { version = "0.10", default-features = false }
 
 [dev-dependencies]
 proc-macro2 = {version = "1.0.47", features = ["span-locations"]}
@@ -37,3 +37,6 @@ members = [
     "examples/html-to-string-macro"
 ]
 
+[features]
+default = ["colors"]
+colors = ["proc-macro2-diagnostics/colors"]


### PR DESCRIPTION
this allows disabling colored diagnostics, which have garbled output filled with control codes when using an ide.