### PR TITLE
feat: impl Parse for NodeBlock

### DIFF
--- a/src/node/node_value.rs
+++ b/src/node/node_value.rs
@@ -4,7 +4,9 @@ use std::convert::TryFrom;
 
 use proc_macro2::TokenStream;
 use quote::ToTokens;
-use syn::{token::Brace, Block};
+use syn::{parse::Parse, token::Brace, Block};
+
+use crate::recoverable::RecoverableContext;
 
 /// Block node.
 ///
@@ -66,5 +68,13 @@ impl ToTokens for NodeBlock {
             }
             Self::ValidBlock(b) => b.to_tokens(tokens),
         }
+    }
+}
+
+impl Parse for NodeBlock {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let mut context = RecoverableContext::default();
+        let block = context.parse_recoverable(input);
+        context.parse_result(block).into_result()
     }
 }


### PR DESCRIPTION
If you want I can extend this to other nodes, I just wanted a way to parse a node content to a `NodeBlock` after setting it to only parse raw text. I.e. take the TokenStream and parse it as a block.
