### PR TITLE
Allow multiple puncts in a row in NodeName

### DIFF
--- a/src/node/node_name.rs
+++ b/src/node/node_name.rs
@@ -24,11 +24,6 @@ pub enum NodeNameFragment {
     // In case when name contain more than one Punct in series
     Empty,
 }
-impl NodeNameFragment {
-    fn peek_any(input: ParseStream) -> bool {
-        input.peek(Ident::peek_any) || input.peek(LitInt)
-    }
-}
 
 impl PartialEq<NodeNameFragment> for NodeNameFragment {
     fn eq(&self, other: &NodeNameFragment) -> bool {
@@ -179,7 +174,7 @@ impl NodeName {
         let fork = &input.fork();
         let mut segments = Punctuated::<X, T>::new();
 
-        while !fork.is_empty() && NodeNameFragment::peek_any(fork) {
+        while !fork.is_empty() {
             let ident = NodeNameFragment::parse(fork)?;
             segments.push_value(ident.clone().into());
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -4,7 +4,9 @@ use eyre::Result;
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use rstml::{
-    node::{KeyedAttribute, KeyedAttributeValue, Node, NodeAttribute, NodeElement, NodeType},
+    node::{
+        KeyedAttribute, KeyedAttributeValue, Node, NodeAttribute, NodeElement, NodeName, NodeType,
+    },
     parse2, Parser, ParserConfig,
 };
 use syn::{parse_quote, token::Colon, Block, LifetimeParam, Pat, PatType, Token, TypeParam};
@@ -883,6 +885,12 @@ fn test_empty_input() -> Result<()> {
     assert!(nodes.is_empty());
 
     Ok(())
+}
+
+#[test]
+fn test_consecutive_puncts_in_name() {
+    let name: NodeName = parse_quote! { a--::..d };
+    assert_eq!(name.to_string(), "a--::..d");
 }
 
 fn get_element(nodes: &[Node], element_index: usize) -> &NodeElement {


### PR DESCRIPTION
Removed `NodeNameFragment::peek_any`, since this function should always return `true` because it can be `NodeNameFragment::Empty`. This allows `NodeNameFragment::Empty` to actually separate puncts which allows multiple puncts in a row to be parsed as `NodeName::Punctuated`