### PR TITLE
feat: initial implementation of key value block attributes

### DIFF
--- a/src/node/attribute.rs
+++ b/src/node/attribute.rs
@@ -69,12 +69,6 @@ impl AttributeValueExpr {
 }
 
 #[derive(Clone, Debug, syn_derive::ToTokens)]
-pub struct AttributeValueBlock {
-    pub token_eq: Token![=],
-    pub value: NodeBlock,
-}
-
-#[derive(Clone, Debug, syn_derive::ToTokens)]
 pub enum KeyedAttributeValue {
     Binding(FnBinding),
     Value(AttributeValueExpr),
@@ -263,7 +257,8 @@ impl ParseRecoverable for KeyedAttribute {
                     KVAttributeValue::Expr(parse_quote!(#vbl))
                 }
 
-                Err(_) if input.fork().peek(Brace) => {
+                Err(err) if input.fork().peek(Brace) && parser.config().recover_block => {
+                    parser.push_diagnostic(err);
                     let ivb = parser.parse_simple(input)?;
                     KVAttributeValue::InvalidBraced(ivb)
                 }

--- a/src/node/attribute.rs
+++ b/src/node/attribute.rs
@@ -24,7 +24,7 @@ pub struct AttributeValueExpr {
 #[derive(Clone, Debug, syn_derive::ToTokens)]
 pub enum KVAttributeValue {
     Expr(Expr),
-    Braced(InvalidBlock),
+    InvalidBraced(InvalidBlock),
 }
 
 impl AttributeValueExpr {
@@ -140,7 +140,7 @@ impl KeyedAttribute {
             .to_value()
             .map(|v| match &v.value {
                 KVAttributeValue::Expr(expr) => Some(expr),
-                KVAttributeValue::Braced(_) => None,
+                KVAttributeValue::InvalidBraced(_) => None,
             })
             .flatten()
     }
@@ -265,7 +265,7 @@ impl ParseRecoverable for KeyedAttribute {
 
                 Err(_) if input.fork().peek(Brace) => {
                     let ivb = parser.parse_simple(input)?;
-                    KVAttributeValue::Braced(ivb)
+                    KVAttributeValue::InvalidBraced(ivb)
                 }
                 Err(_) => {
                     let res = fork

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -16,8 +16,8 @@ mod parser_ext;
 mod raw_text;
 
 pub use attribute::{
-    AttributeValueBlock, AttributeValueExpr, FnBinding, KVAttributeValue, KeyedAttribute,
-    KeyedAttributeValue, NodeAttribute,
+    AttributeValueExpr, FnBinding, KVAttributeValue, KeyedAttribute, KeyedAttributeValue,
+    NodeAttribute,
 };
 pub use node_name::{NodeName, NodeNameFragment};
 pub use node_value::{InvalidBlock, NodeBlock};

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -16,7 +16,8 @@ mod parser_ext;
 mod raw_text;
 
 pub use attribute::{
-    AttributeValueExpr, AttributeValueBlock, FnBinding, KeyedAttribute, KeyedAttributeValue, NodeAttribute,
+    AttributeValueBlock, AttributeValueExpr, FnBinding, KVAttributeValue, KeyedAttribute,
+    KeyedAttributeValue, NodeAttribute,
 };
 pub use node_name::{NodeName, NodeNameFragment};
 pub use node_value::{InvalidBlock, NodeBlock};

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -16,7 +16,7 @@ mod parser_ext;
 mod raw_text;
 
 pub use attribute::{
-    AttributeValueExpr, FnBinding, KeyedAttribute, KeyedAttributeValue, NodeAttribute,
+    AttributeValueExpr, AttributeValueBlock, FnBinding, KeyedAttribute, KeyedAttributeValue, NodeAttribute,
 };
 pub use node_name::{NodeName, NodeNameFragment};
 pub use node_value::{InvalidBlock, NodeBlock};

--- a/src/node/node_value.rs
+++ b/src/node/node_value.rs
@@ -8,9 +8,9 @@ use syn::{token::Brace, Block};
 #[derive(Clone, Debug, syn_derive::ToTokens, syn_derive::Parse)]
 pub struct InvalidBlock {
     #[syn(braced)]
-    brace: Brace,
+    pub brace: Brace,
     #[syn(in = brace)]
-    body: TokenStream,
+    pub body: TokenStream,
 }
 
 /// Block node.

--- a/src/node/parse.rs
+++ b/src/node/parse.rs
@@ -358,7 +358,7 @@ fn block_transform(input: ParseStream, transform_fn: &TransformBlockFn) -> syn::
 }
 
 #[allow(clippy::needless_pass_by_ref_mut)]
-fn parse_valid_block_expr(
+pub(crate) fn parse_valid_block_expr(
     parser: &mut RecoverableContext,
     input: syn::parse::ParseStream,
 ) -> syn::Result<Block> {

--- a/src/parser/recoverable.rs
+++ b/src/parser/recoverable.rs
@@ -191,6 +191,7 @@ impl RecoverableContext {
 
 ///
 /// Result of parsing.
+#[derive(Debug)]
 pub enum ParsingResult<T> {
     /// Fully valid ast that was parsed without errors.
     Ok(T),

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -91,6 +91,13 @@ pub trait Visitor<Custom> {
     ) -> bool {
         true
     }
+    fn visit_attribute_block(
+        &mut self,
+        _key: &mut NodeName,
+        _value: &mut AttributeValueBlock,
+    ) -> bool {
+        true
+    }
 }
 
 #[derive(Debug, Default, Clone, PartialEq, PartialOrd, Ord, Copy, Eq)]
@@ -344,6 +351,7 @@ where
             KeyedAttributeValue::None => self.visit_attribute_flag(&mut attribute.key),
             KeyedAttributeValue::Binding(b) => self.visit_attribute_binding(&mut attribute.key, b),
             KeyedAttributeValue::Value(v) => self.visit_attribute_value(&mut attribute.key, v),
+            KeyedAttributeValue::Block(b) => self.visit_attribute_block(&mut attribute.key, b),
         }
     }
     fn visit_attribute_flag(&mut self, key: &mut NodeName) -> bool {
@@ -367,6 +375,16 @@ where
 
         self.visit_node_name(key);
         self.visit_rust_code(RustCode::Expr(&mut value.value))
+    }
+    fn visit_attribute_block(
+        &mut self,
+        key: &mut NodeName,
+        value: &mut AttributeValueBlock,
+    ) -> bool {
+        visit_inner!(self.visitor.visit_attribute_block(key, value));
+
+        self.visit_node_name(key);
+        self.visit_block(&mut value.value)
     }
 
     fn visit_invalid_block(&mut self, block: &mut InvalidBlock) -> bool {

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -553,16 +553,6 @@ mod tests {
     }
 
     #[test]
-    fn asd() {
-        let a = quote! {
-            <MyComponent style={{width: "20vw"}} />
-        };
-
-        let a = crate::parse2(a);
-        dbg!(a);
-    }
-
-    #[test]
     fn collect_rust_blocks() {
         #[derive(Default)]
         struct TestVisitor {

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -375,7 +375,7 @@ where
         self.visit_node_name(key);
         match &mut value.value {
             KVAttributeValue::Expr(expr) => self.visit_rust_code(RustCode::Expr(expr)),
-            KVAttributeValue::Braced(braced) => self.visit_invalid_block(braced),
+            KVAttributeValue::InvalidBraced(braced) => self.visit_invalid_block(braced),
         }
     }
     fn visit_attribute_block(

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -351,7 +351,6 @@ where
             KeyedAttributeValue::None => self.visit_attribute_flag(&mut attribute.key),
             KeyedAttributeValue::Binding(b) => self.visit_attribute_binding(&mut attribute.key, b),
             KeyedAttributeValue::Value(v) => self.visit_attribute_value(&mut attribute.key, v),
-            KeyedAttributeValue::Block(b) => self.visit_attribute_block(&mut attribute.key, b),
         }
     }
     fn visit_attribute_flag(&mut self, key: &mut NodeName) -> bool {
@@ -374,7 +373,10 @@ where
         visit_inner!(self.visitor.visit_attribute_value(key, value));
 
         self.visit_node_name(key);
-        self.visit_rust_code(RustCode::Expr(&mut value.value))
+        match &mut value.value {
+            KVAttributeValue::Expr(expr) => self.visit_rust_code(RustCode::Expr(expr)),
+            KVAttributeValue::Braced(braced) => self.visit_invalid_block(braced),
+        }
     }
     fn visit_attribute_block(
         &mut self,
@@ -548,6 +550,16 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(node_names, vec!["div", "span", "span", "foo"]);
+    }
+
+    #[test]
+    fn asd() {
+        let a = quote! {
+            <MyComponent style={{width: "20vw"}} />
+        };
+
+        let a = crate::parse2(a);
+        dbg!(a);
     }
 
     #[test]

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -91,13 +91,6 @@ pub trait Visitor<Custom> {
     ) -> bool {
         true
     }
-    fn visit_attribute_block(
-        &mut self,
-        _key: &mut NodeName,
-        _value: &mut AttributeValueBlock,
-    ) -> bool {
-        true
-    }
 }
 
 #[derive(Debug, Default, Clone, PartialEq, PartialOrd, Ord, Copy, Eq)]
@@ -377,16 +370,6 @@ where
             KVAttributeValue::Expr(expr) => self.visit_rust_code(RustCode::Expr(expr)),
             KVAttributeValue::InvalidBraced(braced) => self.visit_invalid_block(braced),
         }
-    }
-    fn visit_attribute_block(
-        &mut self,
-        key: &mut NodeName,
-        value: &mut AttributeValueBlock,
-    ) -> bool {
-        visit_inner!(self.visitor.visit_attribute_block(key, value));
-
-        self.visit_node_name(key);
-        self.visit_block(&mut value.value)
     }
 
     fn visit_invalid_block(&mut self, block: &mut InvalidBlock) -> bool {


### PR DESCRIPTION
This is my initial attempt at implementing block support for the Key-value attribute described in #48 by adding another variant of [`NodeBlock`](https://docs.rs/rstml/0.11.2/rstml/node/enum.NodeBlock.html) into [`KeyedAttributeValue`](https://docs.rs/rstml/0.11.2/rstml/node/enum.KeyedAttributeValue.html#). I also implement [`ParseRecoverable`](https://docs.rs/rstml/0.11.2/rstml/recoverable/trait.ParseRecoverable.html#) trait for [`KeyedAttribute`](https://docs.rs/rstml/0.11.2/rstml/node/struct.KeyedAttribute.html#) so that [`transform_block()`](https://docs.rs/rstml/0.11.2/rstml/struct.ParserConfig.html#method.transform_block) will work inside key-value attributes.

```rs
// Placeholder, implement this to meet your requirements
let parse_cfg = ParserConfig::new().transform_block(|input| {
    println!("handled");
    dbg!(input);
    while let Ok(_) = input.parse::<TokenTree>() {}
    return Ok(Some(quote!("handled").into()));
});

let token= quote!(
    <Route
        style={{ width: "10vw" }}
        view={<MyView />}
        ext={anything is possible here!}></Route>
);
dbg!(Parser::new(parse_cfg).parse_simple(token));
```